### PR TITLE
Ignore when helper files are missing

### DIFF
--- a/build.go
+++ b/build.go
@@ -17,16 +17,24 @@ const openSslLoaderName = "openssl-certificate-loader"
 func Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result := libcnb.BuildResult{}
 
+
+
 	logger := log.NewPaketoLogger(os.Stdout)
 	logger.Title(context.Buildpack.Info.Name, context.Buildpack.Info.Version, context.Buildpack.Info.Homepage)
 
 	//read the env vars set via the extension.
 	versionb, err := os.ReadFile(javaVersionBuilderFile)
 	if err != nil {
+		if os.IsNotExist(err){
+			return result,nil
+		}
 		return result, err
 	}
 	helperb, err := os.ReadFile(javaHelpersBuilderFile)
 	if err != nil {
+		if os.IsNotExist(err){
+			return result,nil
+		}		
 		return result, err
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The helper buildpack is designed to run when the extension runs, but is intended to be a no-op if run by mistake. This allows it to be present in other builders that may not even contain the extension. Today, this fails, because the helper buildpack expects all errors reading the files to be build errors. 

## Use Cases
<!-- An explanation of the use cases your change enables -->
A user includes the buildpack manually, or runs the builder image on a platform that does not support image extensions

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
